### PR TITLE
Disable default features for serialport to ditch libudev

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 [dependencies]
 base64 = "0.13"
 nix = "0.23"
-serialport = "4.0"
+serialport = { version = "4.0", default-features = false }
 subprocess = "0.2"
 tokio = { version = "1", features = ["full"] }
 strum = "0.23"


### PR DESCRIPTION
libudev is really heavy as it needs a daemon and that's cringe