### PR TITLE
Use split(" ") instead of split_whitespace()

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -106,7 +106,7 @@ async fn process_cmds(
 ) -> Result<String, String> {
     // Tokenize and parse the command
     let cmd = String::from_utf8_lossy(serial_buf);
-    let cmd_tokens: Vec<&str> = cmd.split_whitespace().collect();
+    let cmd_tokens: Vec<&str> = cmd.split(" ").collect();
 
     match cmd_tokens.as_slice() {
         ["run", process_name, args, env_vars] => {


### PR DESCRIPTION
Fixes #6 

1- We know that arguments are seperated by ASCII spaces, not weird ass utf8 whitespace
2- Multiple spaces means theres an argument that is an empty string (for the sake of example, spaces are replaced with |) `run arg1||arg3` means that arg1 = arg1, arg2 = "" and arg3 = arg3