### PR TITLE
Exit codes are properly encoded now. Signaled processes have an exit code of 256 + signal and exit code 256 means the exit code could not be determined.

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,10 @@ pid: (INT) process ID of the created process
 
 pid: (NUM) Process ID of the subprocess that exit
 
-exitCode: (NUM) exit code of the subprocess that exit
+exitCode: (NUM) exit code of the subprocess that exit. 
+    0-255: Exited via exit(), exit code is exitCode
+    256: Exit code or signal could not be determined
+    257-inf: Exited by being kill()'d. Signal is (exitCode - 256)
 
 ###### Example
 


### PR DESCRIPTION
//0-255: Exit codes
//256: Undetermined
//257-inf: Signaled

Fixes #7 