### PR TITLE
Fixes error newline being b64 encoded by moving newlines on errors outside the error and in the write_all() in main

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -77,7 +77,7 @@ async fn main() {
                             .expect("Error writing to serial");
                     }
                     Err(e) => {
-                        port.write_all(format!("{}ERR\0", encode(&e)).as_bytes())
+                        port.write_all(format!("{}\nERR\0", encode(&e)).as_bytes())
                             .expect("Error writing to serial");
                     }
                 }
@@ -116,7 +116,7 @@ async fn process_cmds(
         ["poll"] => poll::send_poll_data(poll_data),
         _ => {
             eprintln!("Unknown cmd: {}", cmd);
-            Err(format!("Unknown cmd: {}\n", cmd))
+            Err(format!("Unknown cmd: {}", cmd))
         }
     }
 }

--- a/src/process.rs
+++ b/src/process.rs
@@ -29,19 +29,19 @@ pub async fn process(
     let process = match decode(b_process) {
         Ok(dec_vec) if dec_vec.is_empty() => "".into(),
         Ok(dec_vec) => String::from_utf8(dec_vec).expect("Invalid UTF8 for exec path"),
-        Err(e) => return Err(format!("Error decoding exec path: {}\n", e.to_string())),
+        Err(e) => return Err(format!("Error decoding exec path: {}", e.to_string())),
     };
 
     let args = match decode(b_args) {
         Ok(dec_vec) if dec_vec.is_empty() => "".into(),
         Ok(dec_vec) => String::from_utf8(dec_vec).expect("Invalid UTF8 for exec args"),
-        Err(e) => return Err(format!("Error decoding exec args: {}\n", e.to_string())),
+        Err(e) => return Err(format!("Error decoding exec args: {}", e.to_string())),
     };
 
     let raw_env_vars = match decode(b_env_vars) {
         Ok(dec_vec) if dec_vec.is_empty() => "".into(),
         Ok(dec_vec) => String::from_utf8(dec_vec).expect("Invalid UTF8 for exec env args"),
-        Err(e) => return Err(format!("Error decoding exec env vars: {}\n", e.to_string())),
+        Err(e) => return Err(format!("Error decoding exec env vars: {}", e.to_string())),
     };
 
     // Handle environment vars parsing into tuples
@@ -152,5 +152,6 @@ pub async fn process(
         }
     });
 
+    //TODO: Replace with pid
     Ok("OK\n".into())
 }

--- a/src/signal.rs
+++ b/src/signal.rs
@@ -15,7 +15,7 @@ pub fn send_signal(pid: &&str, signal: &&str) -> Result<String, String> {
     ) {
         Ok(_) => Ok("".into()),
         Err(e) => Err(format!(
-            "Error sending signal {} to pid {}: {}\n",
+            "Error sending signal {} to pid {}: {}",
             sig, pid, e
         )),
     }


### PR DESCRIPTION
Fixes #5