### PR TITLE
Adds an error if env vars don't follow the spec and omit the final semicolon. Previously it would silently ignore the last env var.

### DIFF
--- a/src/process.rs
+++ b/src/process.rs
@@ -96,6 +96,9 @@ pub async fn process(
             _ => add_char(&char, &state, &mut tmpkey, &mut tmpval),
         }
     }
+    if state != EnvParserState::Key {
+        return Err("Env args are unterminated".to_string());
+    }
 
     let poll_data = poll_data_main.clone();
 


### PR DESCRIPTION
Fixes #16 

Wasn't bad code so much as bad input and lack of validation